### PR TITLE
[s-mr1] genfs_contexts: Add missing entry for sm5038-usbpd

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -17,10 +17,8 @@ genfscon sysfs /devices/platform/soc/5c1c000.qcom,cci                           
 
 genfscon sysfs /devices/platform/soc/5e00000.qcom,mdss_mdp/backlight/panel0-backlight                                                        u:object_r:sysfs_leds:s0
 
-# haptic_nv
 genfscon sysfs /devices/platform/soc/4c90000.i2c/i2c-2/2-0058/leds/vibrator                                                                  u:object_r:sysfs_leds:s0
-# ti_haptic
-genfscon sysfs /devices/platform/soc/4c90000.i2c/i2c-2/2-005a/leds/vibrator                                                                  u:object_r:sysfs_leds:s0
 
 genfscon sysfs /devices/platform/soc/4a80000.i2c/i2c-3/3-0049/sm5038-charger/power_supply/battery                                            u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/4a80000.i2c/i2c-3/3-0049/sm5038-muic/power_supply/pc_port                                               u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/4c84000.i2c/i2c-0/0-0033/power_supply/usb                                                               u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
Add missing entry for sm5038-usbpd. Also remove entry for ti_haptics. After a little investigation we came to the conclusion that Murray platform only uses the aw86224 module.