### PR TITLE
Bluetooth Fixes

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -335,7 +335,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # QCOM Bluetooth
 PRODUCT_PACKAGES += \
-    android.hardware.bluetooth@1.0-impl-qti \
+    android.hardware.bluetooth@1.0-impl \
     android.hardware.bluetooth@1.0-service-qti
 
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/platform.mk
+++ b/platform.mk
@@ -336,7 +336,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # QCOM Bluetooth
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-impl \
-    android.hardware.bluetooth@1.0-service-qti
+    android.hardware.bluetooth@1.0-service
 
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.qcom.bluetooth.soc=hastings


### PR DESCRIPTION
In this Pull request we are dropping the non existent  package     android.hardware.bluetooth@1.0-impl-qti  and including the android.hardware.bluetooth@1.0-impl.
And the second commit we are switching  to  android.hardware.bluetooth@1.0-service from android.hardware.bluetooth@1.0-service-qti

We are currently using android.hardware.bluetooth@1.0-service-qti which is from Android 9(https://github.com/sonyxperiadev/vendor-qcom-opensource-bluetooth/tree/master/interfaces/bluetooth/1.0/qti)
Let us switch to the android.hardware.bluetooth@1.0-service provided in AOSP, which contains the same service but with updated rc file (https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-14.0.0_r10/bluetooth/1.0/default/)
With this change we can drop vendor/qcom/opensource/Bluetooth